### PR TITLE
feat: Make alert evaluation window configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Every alert supports the following overrides:
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| alert\_relative\_time\_range\_from | Relative time range (seconds) for alert evaluation window | `number` | `600` | no |
 | datasource\_uid | The UID of the Grafana datasource being queried with the expressions inside the Alerting rule file | `string` | n/a | yes |
 | default\_evaluation\_interval\_duration | How often is the rule evaluated by default. (When not defined inside your Alerting rules file) | `string` | `"5m"` | no |
 | disable\_provenance | Allow modifying the rule group from other sources than Terraform or the Grafana API. | `bool` | `false` | no |

--- a/grafana_alert.tf
+++ b/grafana_alert.tf
@@ -41,7 +41,7 @@ resource "grafana_rule_group" "this" {
       data {
         ref_id = "QUERY"
         relative_time_range {
-          from = 600
+          from = var.alert_relative_time_range_from
           to   = 0
         }
         datasource_uid = var.datasource_uid
@@ -58,7 +58,7 @@ resource "grafana_rule_group" "this" {
       data {
         ref_id = "QUERY_RESULT"
         relative_time_range {
-          from = 600
+          from = var.alert_relative_time_range_from
           to   = 0
         }
         datasource_uid = "__expr__"
@@ -100,7 +100,7 @@ resource "grafana_rule_group" "this" {
       data {
         ref_id = "ALERTCONDITION"
         relative_time_range {
-          from = 600
+          from = var.alert_relative_time_range_from
           to   = 0
         }
         datasource_uid = "__expr__"

--- a/variables.tf
+++ b/variables.tf
@@ -45,3 +45,9 @@ variable "disable_provenance" {
   type        = bool
   default     = false
 }
+
+variable "alert_relative_time_range_from" {
+  description = "Relative time range (seconds) for alert evaluation window"
+  type        = number
+  default     = 600
+}


### PR DESCRIPTION
Resolves #11 

Hi @yevhenyaremenko, sorry for the slow answer. I implemented your proposed change (make it configurable) but I kept the default as-is to not break my installation. But at a later step (in the future) I can probably lower it.