### PR TITLE
feat: Allow to globally control the default of exec_err_state

### DIFF
--- a/.github/workflows/terratest.yaml
+++ b/.github/workflows/terratest.yaml
@@ -34,6 +34,7 @@ jobs:
           go test -v
 
       - name: Check for updated README (terraform-docs)
+        # When you update the next line, please also update the version constraint in .terraform-docs.yml
         uses: terraform-docs/gh-actions@6de6da0cefcc6b4b7a5cbea4d79d97060733093c # v1.4.1
         with:
           working-dir: .

--- a/.terraform-docs.yml
+++ b/.terraform-docs.yml
@@ -12,3 +12,5 @@ sections:
     - providers
     - inputs
     - outputs
+
+version: "0.20.0"

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Every alert supports the following overrides:
 | alert\_relative\_time\_range\_from | Relative time range (seconds) for alert evaluation window | `number` | `600` | no |
 | datasource\_uid | The UID of the Grafana datasource being queried with the expressions inside the Alerting rule file | `string` | n/a | yes |
 | default\_evaluation\_interval\_duration | How often is the rule evaluated by default. (When not defined inside your Alerting rules file) | `string` | `"5m"` | no |
+| default\_exec\_err\_state | Describes what state to enter when the rule's query is invalid and the rule cannot be executed. Options are `OK`, `Error`, `KeepLast`, and `Alerting`. | `string` | `"Error"` | no |
 | disable\_provenance | Allow modifying the rule group from other sources than Terraform or the Grafana API. | `bool` | `false` | no |
 | folder\_uid | The UID of the Grafana folder that the alerts belongs to. | `string` | n/a | yes |
 | org\_id | The Organization ID of of the Grafana Alerting rule groups. (Only supported with basic auth, API keys are already org-scoped) | `string` | `null` | no |

--- a/grafana_alert.tf
+++ b/grafana_alert.tf
@@ -34,7 +34,7 @@ resource "grafana_rule_group" "this" {
       }
       labels = merge(rule.value.labels, try(var.overrides[rule.value.alert].labels, {}))
 
-      exec_err_state = coalesce(try(var.overrides[rule.value.alert].exec_err_state, null), "Error")
+      exec_err_state = coalesce(try(var.overrides[rule.value.alert].exec_err_state, null), var.default_exec_err_state)
       is_paused      = try(var.overrides[rule.value.alert].is_paused, null)
       no_data_state  = coalesce(try(var.overrides[rule.value.alert].no_data_state, null), "OK")
 

--- a/variables.tf
+++ b/variables.tf
@@ -34,6 +34,12 @@ variable "default_evaluation_interval_duration" {
   default     = "5m"
 }
 
+variable "default_exec_err_state" {
+  description = "Describes what state to enter when the rule's query is invalid and the rule cannot be executed. Options are `OK`, `Error`, `KeepLast`, and `Alerting`."
+  type        = string
+  default     = "Error"
+}
+
 variable "org_id" {
   description = "The Organization ID of of the Grafana Alerting rule groups. (Only supported with basic auth, API keys are already org-scoped)"
   type        = string


### PR DESCRIPTION
## Description
Until now it was possible to change the `exec_err_state` on a per-rule basis.
This PR adds the ability to control the default of this field.

## Motivation and Context
We aim to move the majority of our alerting rules from `Error` to `Alerting`.

## Breaking Changes
none

## How Has This Been Tested?
- [X] I have tested and validated these changes using an example rule