### PR TITLE
feat: Make default alert_threshold configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Every alert supports the following overrides:
 |------|-------------|------|---------|:--------:|
 | alert\_relative\_time\_range\_from | Relative time range (seconds) for alert evaluation window | `number` | `600` | no |
 | datasource\_uid | The UID of the Grafana datasource being queried with the expressions inside the Alerting rule file | `string` | n/a | yes |
+| default\_alert\_threshold | The default threshold for alerting rules. | `number` | `0` | no |
 | default\_evaluation\_interval\_duration | How often is the rule evaluated by default. (When not defined inside your Alerting rules file) | `string` | `"5m"` | no |
 | default\_exec\_err\_state | Describes what state to enter when the rule's query is invalid and the rule cannot be executed. Options are `OK`, `Error`, `KeepLast`, and `Alerting`. | `string` | `"Error"` | no |
 | disable\_provenance | Allow modifying the rule group from other sources than Terraform or the Grafana API. | `bool` | `false` | no |

--- a/grafana_alert.tf
+++ b/grafana_alert.tf
@@ -108,7 +108,7 @@ resource "grafana_rule_group" "this" {
           "conditions" = [
             {
               "evaluator" = {
-                "params" = [coalesce(try(var.overrides[rule.value.alert].alert_threshold, null), 0)]
+                "params" = [coalesce(try(var.overrides[rule.value.alert].alert_threshold, null), var.default_alert_threshold)]
                 "type"   = "gt"
               }
               "operator" = {

--- a/variables.tf
+++ b/variables.tf
@@ -40,6 +40,12 @@ variable "default_exec_err_state" {
   default     = "Error"
 }
 
+variable "default_alert_threshold" {
+  description = "The default threshold for alerting rules."
+  type        = number
+  default     = 0
+}
+
 variable "org_id" {
   description = "The Organization ID of of the Grafana Alerting rule groups. (Only supported with basic auth, API keys are already org-scoped)"
   type        = string


### PR DESCRIPTION
## Description
Sometimes `0` is not what we want for a couple of alerts.
With this new feature, we don't have to define an override for every alert.

## Motivation and Context
See above

## Breaking Changes
none

## How Has This Been Tested?
- [X] I have tested and validated these changes using an example rule
