### PR TITLE
feat: Allow overriding alert threshold type

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,16 +68,17 @@ module "cert_manager_rules" {
 
 Every alert supports the following overrides:
 
-| Override parameter | Type          | Description |
-|--------------------|---------------|-------------|
-| `alert_threshold`  | `number`      | Threshold of the Grafana alert. Defaults to `0` |
-| `exec_err_state`   | `string`      | Describes what state to enter when the rule's query is invalid and the rule cannot be executed. Options are `OK`, `Error`, `KeepLast`, and `Alerting`. Defaults to `Error`. |
-| `expr`             | `string`      | Use a custom PromQL expression for this Grafana alert. |
-| `is_paused`        | `bool`        | Sets whether the alert should be paused or not. Defaults to `false`. |
-| `no_data_state`    | `string`      | Describes what state to enter when the rule's query returns No Data. Options are `OK`, `NoData`, `KeepLast`, and `Alerting`. Defaults to `OK`. |
-| `annotations`      | `map(string)` | Extra annotations to add. It is also possible to override already defined annotations like `runbook_url`. |
-| `labels`           | `map(string)` | Extra labels to add. It is also possible to override already defined labels like `severity`. |
-| `for`              | `string`      | The amount of time for which the rule must be breached for the rule to be considered to be *Firing*. Before this time has elapsed, the rule is only considered to be *Pending*. Defaults to `0`. |
+| Override parameter     | Type          | Description |
+|------------------------|---------------|-------------|
+| `alert_threshold`      | `number`      | Threshold of the Grafana alert. Defaults to `0` |
+| `alert_threshold_type` | `string`      | Threshold type of the Grafana alert. Options are `gt` (above), `lt` (below), `eq` (equal), `ne` (not equal), `gte` (above or equal), and `lte` (below or equal). Defaults to `gt` |
+| `exec_err_state`       | `string`      | Describes what state to enter when the rule's query is invalid and the rule cannot be executed. Options are `OK`, `Error`, `KeepLast`, and `Alerting`. Defaults to `Error`. |
+| `expr`                 | `string`      | Use a custom PromQL expression for this Grafana alert. |
+| `is_paused`            | `bool`        | Sets whether the alert should be paused or not. Defaults to `false`. |
+| `no_data_state`        | `string`      | Describes what state to enter when the rule's query returns No Data. Options are `OK`, `NoData`, `KeepLast`, and `Alerting`. Defaults to `OK`. |
+| `annotations`          | `map(string)` | Extra annotations to add. It is also possible to override already defined annotations like `runbook_url`. |
+| `labels`               | `map(string)` | Extra labels to add. It is also possible to override already defined labels like `severity`. |
+| `for`                  | `string`      | The amount of time for which the rule must be breached for the rule to be considered to be *Firing*. Before this time has elapsed, the rule is only considered to be *Pending*. Defaults to `0`. |
 
 
 ## TF module documentation
@@ -101,7 +102,7 @@ Every alert supports the following overrides:
 | disable\_provenance | Allow modifying the rule group from other sources than Terraform or the Grafana API. | `bool` | `false` | no |
 | folder\_uid | The UID of the Grafana folder that the alerts belongs to. | `string` | n/a | yes |
 | org\_id | The Organization ID of of the Grafana Alerting rule groups. (Only supported with basic auth, API keys are already org-scoped) | `string` | `null` | no |
-| overrides | Overrides per Alert rule | <pre>map(object({<br/>    alert_threshold = optional(number)<br/>    exec_err_state  = optional(string)<br/>    expr            = optional(string)<br/>    is_paused       = optional(bool)<br/>    no_data_state   = optional(string)<br/>    labels          = optional(map(string))<br/>    annotations     = optional(map(string))<br/>    for             = optional(string)<br/>  }))</pre> | `{}` | no |
+| overrides | Overrides per Alert rule | <pre>map(object({<br/>    alert_threshold      = optional(number)<br/>    alert_threshold_type = optional(string)<br/>    exec_err_state       = optional(string)<br/>    expr                 = optional(string)<br/>    is_paused            = optional(bool)<br/>    no_data_state        = optional(string)<br/>    labels               = optional(map(string))<br/>    annotations          = optional(map(string))<br/>    for                  = optional(string)<br/>  }))</pre> | `{}` | no |
 | prometheus\_alerts\_file\_path | Path to the Prometheus Alerting rules file | `string` | n/a | yes |
 
 ### Outputs

--- a/grafana_alert.tf
+++ b/grafana_alert.tf
@@ -109,7 +109,7 @@ resource "grafana_rule_group" "this" {
             {
               "evaluator" = {
                 "params" = [coalesce(try(var.overrides[rule.value.alert].alert_threshold, null), var.default_alert_threshold)]
-                "type"   = "gt"
+                "type"   = coalesce(try(var.overrides[rule.value.alert].alert_threshold_type, null), "gt")
               }
               "operator" = {
                 "type" = "and"

--- a/variables.tf
+++ b/variables.tf
@@ -16,14 +16,15 @@ variable "datasource_uid" {
 variable "overrides" {
   description = "Overrides per Alert rule"
   type = map(object({
-    alert_threshold = optional(number)
-    exec_err_state  = optional(string)
-    expr            = optional(string)
-    is_paused       = optional(bool)
-    no_data_state   = optional(string)
-    labels          = optional(map(string))
-    annotations     = optional(map(string))
-    for             = optional(string)
+    alert_threshold      = optional(number)
+    alert_threshold_type = optional(string)
+    exec_err_state       = optional(string)
+    expr                 = optional(string)
+    is_paused            = optional(bool)
+    no_data_state        = optional(string)
+    labels               = optional(map(string))
+    annotations          = optional(map(string))
+    for                  = optional(string)
   }))
   default = {}
 }


### PR DESCRIPTION
## Description
Sometimes we want to alert, when the query value `is below X`. Until now our module only supported `is above X`.

## Motivation and Context
See above

**Reviewers note:** Enable "hide whitespaces" for an easier review.

## Breaking Changes
none

## How Has This Been Tested?
- [X] I have tested and validated these changes using an example rule
